### PR TITLE
Add a default value for --libjs-test262-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,14 @@ Finally, clone or sync test262 itself:
 
 ## Usage
 
-In the below command, `LADYBIRD_SOURCE_DIR` should point to the Ladybird checkout. The exact path to `test262-runner`
-may vary depending on any extra options that were provided to `ladybird.py` above.
+If you've built Ladybird with its default configuration, and you have set `LADYBIRD_SOURCE_DIR` to point at your Ladybird
+checkout, you can run the following command to run all tests:
+
+```bash
+./main.py
+```
+
+You may also override the path to the test262-runner and the path to the test262 tests:
 
 ```bash
 ./main.py --libjs-test262-runner "${LADYBIRD_SOURCE_DIR}/Build/release/bin/test262-runner" --test262-root ./test262

--- a/main.py
+++ b/main.py
@@ -494,7 +494,23 @@ class Runner:
         self.log(f"Finished running tests in {self.duration}.")
 
 
+def default_test262_runner_path() -> Path | None:
+    ladybird_source_dir = os.environ.get("LADYBIRD_SOURCE_DIR")
+
+    if ladybird_source_dir:
+        default_test262_runner = (
+            Path(ladybird_source_dir) / "Build" / "release" / "bin" / "test262-runner"
+        )
+
+        if default_test262_runner.exists():
+            return default_test262_runner
+
+    return None
+
+
 def main() -> None:
+    default_test262_runner = default_test262_runner_path()
+
     parser = ArgumentParser(
         description="Run the test262 ECMAScript test suite with Ladybird's LibJS",
         epilog=", ".join(f"{EMOJIS[result]} = {result.value}" for result in TestResult),
@@ -502,7 +518,8 @@ def main() -> None:
     parser.add_argument(
         "-j",
         "--libjs-test262-runner",
-        required=True,
+        required=default_test262_runner is None,
+        default=str(default_test262_runner) if default_test262_runner else None,
         metavar="PATH",
         help="path to the 'test262-runner' binary",
     )


### PR DESCRIPTION
If LADYBIRD_SOURCE_DIR is set and the default (release) build exists, let's default the --libjs-test262-runner flag to that path.